### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/mightyLooperControls/keywords.txt
+++ b/mightyLooperControls/keywords.txt
@@ -6,26 +6,26 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-MlSimpleButton 	KEYWORD1
-MlMultiButton 	KEYWORD1
-MlChannelButton KEYWORD1
-MlTrackButton 	KEYWORD1
+MlSimpleButton	KEYWORD1
+MlMultiButton	KEYWORD1
+MlChannelButton	KEYWORD1
+MlTrackButton	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-update			KEYWORD2
-getSignal		KEYWORD2
+update	KEYWORD2
+getSignal	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-SINGLE_PRESS 	LITERAL1
-DOUBLE_PRESS 	LITERAL1
-LONG_PRESS 		LITERAL1
+SINGLE_PRESS	LITERAL1
+DOUBLE_PRESS	LITERAL1
+LONG_PRESS	LITERAL1
 
-CURRENT 			LITERAL1
-LAST 					LITERAL1
-NEW_PRESS			LITERAL1
+CURRENT	LITERAL1
+LAST	LITERAL1
+NEW_PRESS	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords